### PR TITLE
useProductImpression

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
 node_modules
-CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `useProductImpression` hook.
+
+### Changed
+-  the context's state props' names and dispatch actions.
 
 ## [0.1.1] - 2020-01-03
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `useProductImpression` hook.
 
 ### Changed
--  the context's state props' names and dispatch actions.
+-  The context's state props' names and dispatch actions.
 
 ## [0.1.1] - 2020-01-03
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,30 +28,49 @@ return (
 )
 ```
 
-The Product List Context state is comprised of a object with a single property: `visibleProducts`.
+The Product List Context state is comprised of a object with the following properties: `nextImpressions`: List of products that are going to be sent on the product impression event.
+`sentIds`: Set of the IDs of the products that were already impressed or are marked to be impressed.
 
-You can use two Hooks to handle the data contained in the Product List Context object: 'useProductListState' and 'useProductListDispatch'.
+You can use two Hooks to handle the data contained in the Product List Context object: `useProductListState` and `useProductListDispatch`.
 
 `useProductListState`: used to get the data stored in the context. In order to use it, you need to first import and then call the hook anywhere in any file under the component which is wrapped by ProductListProvider. For example:
 
 ```tsx
-import { useProductListState } from 'vtex.product-list-context/ProductListContext'
-const { visibleProducts } = useProductListState()
+import { ProductListContext } from 'vtex.product-list-context'
+
+...
+const { useProductListState } = ProductListContext
+const { nextImpressions } = useProductListState()
 ```
 
 `useProductListDispatch`: returns a dispatch function that is used to change the context state. Notice that you should only import and declare this hook if you wish to change data that's stored in the context.
 
 ```tsx
-import { useProductListDispatch } from 'vtex.product-list-context/ProductListContext'
+import { ProductListContext } from 'vtex.product-list-context'
+
+...
+const { useProductListDispatch } = ProductListContext
 const dispatch = useProductListDispatch()
 ```
 
-Starting from the dispatch function, you can add new values to the `visibleProducts` array (ADD_VISIBLE_PRODUCT) or clear all current existing object values (RESET_VISIBLE_PRODUCTS). For example:
+Starting from the dispatch function, you can add new values to the `nextImpressions` array (`SEND_IMPRESSION`) or clear this array (`CLEAR_TO_BE_SENT`). For example:
 
 ```tsx
 const dispatch = useProductListDispatch()  useEffect(() => {
   if (inView) {
-    dispatch({ type: 'ADD_VISIBLE_PRODUCT', args: { product: product }})
+    dispatch({ type: 'SEND_IMPRESSION', args: { product: product }})
   }
 }, [inView])
 ```
+
+This app also contains `useProductImpression`, which is a hook that you can call when you want to send impression events of the products in the `nextImpressions` array. For example:
+
+```tsx
+import { useProductImpression } from 'vtex.product-list-context'
+
+...
+
+useProductImpression()
+```
+
+When calling this hook, the `product-list-context` will always check if there is anything in the `nextImpressions` array. If there is, and the array doesn't change for one second, all the products in it will be impressed and the array will be cleared.

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,9 +38,10 @@ You can use two Hooks to handle the data contained in the Product List Context o
 ```tsx
 import { ProductListContext } from 'vtex.product-list-context'
 
-...
-const { useProductListState } = ProductListContext
-const { nextImpressions } = useProductListState()
+//...
+
+  const { useProductListState } = ProductListContext
+  const { nextImpressions } = useProductListState()
 ```
 
 `useProductListDispatch`: returns a dispatch function that is used to change the context state. Notice that you should only import and declare this hook if you wish to change data that's stored in the context.
@@ -48,12 +49,13 @@ const { nextImpressions } = useProductListState()
 ```tsx
 import { ProductListContext } from 'vtex.product-list-context'
 
-...
-const { useProductListDispatch } = ProductListContext
-const dispatch = useProductListDispatch()
+//...
+
+  const { useProductListDispatch } = ProductListContext
+  const dispatch = useProductListDispatch()
 ```
 
-Starting from the dispatch function, you can add new values to the `nextImpressions` array (`SEND_IMPRESSION`) or clear this array (`CLEAR_TO_BE_SENT`). For example:
+Starting from the dispatch function, you can add new values to the `nextImpressions` array (`SEND_IMPRESSION`) or reset this array (`RESET_NEXT_IMPRESSIONS`). For example:
 
 ```tsx
 const dispatch = useProductListDispatch()  useEffect(() => {
@@ -68,9 +70,9 @@ This app also contains `useProductImpression`, which is a hook that you can call
 ```tsx
 import { useProductImpression } from 'vtex.product-list-context'
 
-...
+//...
 
-useProductImpression()
+  useProductImpression()
 ```
 
-When calling this hook, the `product-list-context` will always check if there is anything in the `nextImpressions` array. If there is, and the array doesn't change for one second, all the products in it will be impressed and the array will be cleared.
+When calling this hook, the `product-list-context` will always check if there is anything in the `nextImpressions` array. If there is, and the array doesn't change for one second, all the products in it will be impressed and the array will be reseted.

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,9 @@
     "react": "3.x",
     "docs": "0.x"
   },
-  "dependencies": {},
+  "dependencies": {
+    "vtex.pixel-manager": "1.x"
+  },
   "registries": [
     "smartcheckout"
   ],

--- a/react/ProductListContext.tsx
+++ b/react/ProductListContext.tsx
@@ -1,5 +1,9 @@
 import React, { createContext, useContext, useReducer, FC } from 'react'
 
+const DEFAULT_STATE = {
+  nextImpressions: [] as Product[],
+  sentIds: new Set<string>(),
+}
 export interface Product {
   productId: string
   [key: string]: any
@@ -13,8 +17,12 @@ type ReducerActions =
   | { type: 'SEND_IMPRESSION'; args: { product: Product } }
   | { type: 'CLEAR_TO_BE_SENT' }
 
-const ProductListStateContext = createContext({})
-const ProductListDispatchContext = createContext({})
+export type Dispatch = (action: ReducerActions) => void
+
+const ProductListStateContext = createContext<State>(DEFAULT_STATE)
+const ProductListDispatchContext = createContext<Dispatch>(action => {
+  console.error('error in dispatch ', action)
+})
 
 function productListReducer(state: State, action: ReducerActions): State {
   switch (action.type) {

--- a/react/ProductListContext.tsx
+++ b/react/ProductListContext.tsx
@@ -11,7 +11,7 @@ export interface State {
 
 type ReducerActions =
   | { type: 'SEND_IMPRESSION'; args: { product: Product } }
-  | { type: 'CLEAR_TO_BE_SENT' }
+  | { type: 'RESET_NEXT_IMPRESSIONS' }
 
 export type Dispatch = (action: ReducerActions) => void
 
@@ -39,7 +39,7 @@ function productListReducer(state: State, action: ReducerActions): State {
         nextImpressions,
       }
     }
-    case 'CLEAR_TO_BE_SENT': {
+    case 'RESET_NEXT_IMPRESSIONS': {
       return { ...state, nextImpressions: [] }
     }
     default: {

--- a/react/ProductListContext.tsx
+++ b/react/ProductListContext.tsx
@@ -1,27 +1,33 @@
 import React, { createContext, useContext, useReducer, FC } from 'react'
 
-interface State {
-  visibleProducts: any[]
+export interface State {
+  toBeImpressed: any[]
+  seenIds: Set<string>
 }
 
 type ReducerActions =
-  | { type: 'ADD_VISIBLE_PRODUCT'; args: { product: any } }
-  | { type: 'RESET_VISIBLE_PRODUCTS' }
+  | { type: 'ADD_TO_BE_IMPRESSED'; args: { product: any } }
+  | { type: 'RESET_TO_BE_IMPRESSED' }
 
 const ProductListStateContext = createContext({})
 const ProductListDispatchContext = createContext({})
 
 function productListReducer(state: State, action: ReducerActions): State {
   switch (action.type) {
-    case 'ADD_VISIBLE_PRODUCT': {
+    case 'ADD_TO_BE_IMPRESSED': {
       const { product } = action.args
+      let toBeImpressed = state.toBeImpressed
+      if (!state.seenIds.has(product.productId)) {
+        state.seenIds.add(product.productId)
+        toBeImpressed = state.toBeImpressed.concat(product)
+      }
       return {
         ...state,
-        visibleProducts: state.visibleProducts.concat(product),
+        toBeImpressed,
       }
     }
-    case 'RESET_VISIBLE_PRODUCTS': {
-      return { ...state, visibleProducts: [] }
+    case 'RESET_TO_BE_IMPRESSED': {
+      return { ...state, toBeImpressed: [] }
     }
     default: {
       throw new Error(`Unhandled action type on product-list-context`)
@@ -30,7 +36,8 @@ function productListReducer(state: State, action: ReducerActions): State {
 }
 
 const initialState: State = {
-  visibleProducts: [] as any[],
+  toBeImpressed: [] as any[],
+  seenIds: new Set(),
 }
 
 const ProductListProvider: FC = ({ children }) => {

--- a/react/ProductListContext.tsx
+++ b/react/ProductListContext.tsx
@@ -1,9 +1,5 @@
 import React, { createContext, useContext, useReducer, FC } from 'react'
 
-const DEFAULT_STATE = {
-  nextImpressions: [] as Product[],
-  sentIds: new Set<string>(),
-}
 export interface Product {
   productId: string
   [key: string]: any
@@ -18,6 +14,11 @@ type ReducerActions =
   | { type: 'CLEAR_TO_BE_SENT' }
 
 export type Dispatch = (action: ReducerActions) => void
+
+const DEFAULT_STATE: State = {
+  nextImpressions: [],
+  sentIds: new Set<string>(),
+}
 
 const ProductListStateContext = createContext<State>(DEFAULT_STATE)
 const ProductListDispatchContext = createContext<Dispatch>(action => {
@@ -48,7 +49,7 @@ function productListReducer(state: State, action: ReducerActions): State {
 }
 
 const initialState: State = {
-  nextImpressions: [] as Product[],
+  nextImpressions: [],
   sentIds: new Set(),
 }
 

--- a/react/ProductListContext.tsx
+++ b/react/ProductListContext.tsx
@@ -1,33 +1,37 @@
 import React, { createContext, useContext, useReducer, FC } from 'react'
 
+export interface Product {
+  productId: string
+  [key: string]: any
+}
 export interface State {
-  toBeImpressed: any[]
-  seenIds: Set<string>
+  nextImpressions: Product[]
+  sentIds: Set<string>
 }
 
 type ReducerActions =
-  | { type: 'ADD_TO_BE_IMPRESSED'; args: { product: any } }
-  | { type: 'RESET_TO_BE_IMPRESSED' }
+  | { type: 'SEND_IMPRESSION'; args: { product: Product } }
+  | { type: 'CLEAR_TO_BE_SENT' }
 
 const ProductListStateContext = createContext({})
 const ProductListDispatchContext = createContext({})
 
 function productListReducer(state: State, action: ReducerActions): State {
   switch (action.type) {
-    case 'ADD_TO_BE_IMPRESSED': {
+    case 'SEND_IMPRESSION': {
       const { product } = action.args
-      let toBeImpressed = state.toBeImpressed
-      if (!state.seenIds.has(product.productId)) {
-        state.seenIds.add(product.productId)
-        toBeImpressed = state.toBeImpressed.concat(product)
+      let nextImpressions = state.nextImpressions
+      if (!state.sentIds.has(product.productId)) {
+        state.sentIds.add(product.productId)
+        nextImpressions = state.nextImpressions.concat(product)
       }
       return {
         ...state,
-        toBeImpressed,
+        nextImpressions,
       }
     }
-    case 'RESET_TO_BE_IMPRESSED': {
-      return { ...state, toBeImpressed: [] }
+    case 'CLEAR_TO_BE_SENT': {
+      return { ...state, nextImpressions: [] }
     }
     default: {
       throw new Error(`Unhandled action type on product-list-context`)
@@ -36,8 +40,8 @@ function productListReducer(state: State, action: ReducerActions): State {
 }
 
 const initialState: State = {
-  toBeImpressed: [] as any[],
-  seenIds: new Set(),
+  nextImpressions: [] as Product[],
+  sentIds: new Set(),
 }
 
 const ProductListProvider: FC = ({ children }) => {

--- a/react/package.json
+++ b/react/package.json
@@ -4,8 +4,6 @@
     "test": "vtex-test-tools test"
   },
   "dependencies": {
-    "@types/debounce": "^1.2.0",
-    "@types/ramda": "^0.26.39",
     "apollo-client": "^2.6.3",
     "debounce": "^1.2.0",
     "ramda": "^0.26.1",
@@ -15,7 +13,9 @@
     "react-intl": "^2.9.0"
   },
   "devDependencies": {
+    "@types/debounce": "^1.2.0",
     "@types/graphql": "^14.2.2",
+    "@types/ramda": "^0.26.39",
     "@types/react": "^16.8.22",
     "@types/react-intl": "^2.3.18",
     "@vtex/tsconfig": "^0.2.0",

--- a/react/package.json
+++ b/react/package.json
@@ -25,7 +25,7 @@
     "prop-types": "^15.7.2",
     "typescript": "3.7.3",
     "vtex.pixel-manager": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.pixel-manager@1.1.4/public/@types/vtex.pixel-manager",
-    "vtex.render-runtime": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.87.3/public/@types/vtex.render-runtime"
+    "vtex.render-runtime": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.88.0/public/@types/vtex.render-runtime"
   },
   "version": "0.1.1"
 }

--- a/react/package.json
+++ b/react/package.json
@@ -4,7 +4,11 @@
     "test": "vtex-test-tools test"
   },
   "dependencies": {
+    "@types/debounce": "^1.2.0",
+    "@types/ramda": "^0.26.39",
     "apollo-client": "^2.6.3",
+    "debounce": "^1.2.0",
+    "ramda": "^0.26.1",
     "react": "^16.8.6",
     "react-apollo": "^2.5.8",
     "react-dom": "^16.8.6",
@@ -20,7 +24,8 @@
     "prettier": "^1.18.2",
     "prop-types": "^15.7.2",
     "typescript": "3.7.3",
-    "vtex.render-runtime": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.85.0/public/@types/vtex.render-runtime"
+    "vtex.pixel-manager": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.pixel-manager@1.1.4/public/@types/vtex.pixel-manager",
+    "vtex.render-runtime": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.87.3/public/@types/vtex.render-runtime"
   },
   "version": "0.1.1"
 }

--- a/react/useProductImpression.tsx
+++ b/react/useProductImpression.tsx
@@ -34,13 +34,7 @@ const useProductImpression = () => {
   const dispatch = useProductListDispatch()
 
   const debouncedSendImpressionEvents = useCallback(
-    debounce(
-      (nextImpressions: Product[], push: any, dispatch: Dispatch) => {
-        sendImpressionEvents(nextImpressions, push, dispatch)
-      },
-      1000,
-      false
-    ),
+    debounce(sendImpressionEvents, 1000, false),
     []
   )
 

--- a/react/useProductImpression.tsx
+++ b/react/useProductImpression.tsx
@@ -2,11 +2,7 @@ import { useEffect, useCallback } from 'react'
 import debounce from 'debounce'
 import { PixelContext } from 'vtex.pixel-manager'
 
-import productImpressionHooks, {
-  State,
-  Product,
-  Dispatch,
-} from './ProductListContext'
+import productImpressionHooks, { Product, Dispatch } from './ProductListContext'
 import { parseToProductImpression } from './utils/parser'
 
 const { useProductListDispatch, useProductListState } = productImpressionHooks
@@ -19,7 +15,7 @@ const sendImpressionEvents = (
   if (!products || products.length <= 0) {
     return
   }
-  const parsedProducts = products.map(parseToProductImpression) as Product[]
+  const parsedProducts = products.filter(Boolean).map(parseToProductImpression)
   const impressions = parsedProducts.map((product: Product, index: number) => ({
     product,
     position: index + 1,
@@ -33,7 +29,7 @@ const sendImpressionEvents = (
 }
 
 const useProductImpression = () => {
-  const { nextImpressions } = useProductListState() as State
+  const { nextImpressions } = useProductListState()
   const { push } = PixelContext.usePixel()
   const dispatch = useProductListDispatch()
 

--- a/react/useProductImpression.tsx
+++ b/react/useProductImpression.tsx
@@ -25,7 +25,7 @@ const sendImpressionEvents = (
     list: 'Shelf',
     impressions,
   })
-  dispatch({ type: 'CLEAR_TO_BE_SENT' })
+  dispatch({ type: 'RESET_NEXT_IMPRESSIONS' })
 }
 
 const useProductImpression = () => {

--- a/react/useProductImpression.tsx
+++ b/react/useProductImpression.tsx
@@ -2,20 +2,24 @@ import { useEffect, useCallback } from 'react'
 import debounce from 'debounce'
 import { PixelContext } from 'vtex.pixel-manager'
 
-import productImpressionHooks, { State, Product } from './ProductListContext'
-import { parseToProductImpression } from './utils/normalize'
+import productImpressionHooks, {
+  State,
+  Product,
+  Dispatch,
+} from './ProductListContext'
+import { parseToProductImpression } from './utils/parser'
 
 const { useProductListDispatch, useProductListState } = productImpressionHooks
 
 const sendImpressionEvents = (
   products: Product[],
   push: any,
-  dispatch: any
+  dispatch: Dispatch
 ) => {
   if (!products || products.length <= 0) {
     return
   }
-  const parsedProducts = products.map(parseToProductImpression)
+  const parsedProducts = products.map(parseToProductImpression) as Product[]
   const impressions = parsedProducts.map((product: Product, index: number) => ({
     product,
     position: index + 1,
@@ -35,7 +39,7 @@ const useProductImpression = () => {
 
   const debouncedSendImpressionEvents = useCallback(
     debounce(
-      (nextImpressions: Product[], push: any, dispatch: any) => {
+      (nextImpressions: Product[], push: any, dispatch: Dispatch) => {
         sendImpressionEvents(nextImpressions, push, dispatch)
       },
       1000,

--- a/react/useProductImpression.tsx
+++ b/react/useProductImpression.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useCallback } from 'react'
+import debounce from 'debounce'
+import { PixelContext } from 'vtex.pixel-manager'
+
+import productImpressionHooks, { State } from './ProductListContext'
+import { parseToProductImpression } from './utils/normalize'
+
+const { useProductListDispatch, useProductListState } = productImpressionHooks
+
+const sendImpressionEvents = (products: any, push: any, dispatch: any) => {
+  if (!products || products.length <= 0) {
+    return
+  }
+  const normalizedProducts = products.map(parseToProductImpression)
+  const impressions = normalizedProducts.map((product: any, index: number) => ({
+    product,
+    position: index + 1,
+  }))
+  push({
+    event: 'productImpression',
+    list: 'Shelf',
+    impressions,
+  })
+  dispatch({ type: 'RESET_TO_BE_IMPRESSED' })
+}
+
+const useProductImpression = () => {
+  const { toBeImpressed } = useProductListState() as State
+  const { push } = PixelContext.usePixel()
+  const dispatch = useProductListDispatch()
+
+  const debouncedSendImpressionEvents = useCallback(
+    debounce(
+      (toBeImpressed: any, push: any, dispatch: any) => {
+        sendImpressionEvents(toBeImpressed, push, dispatch)
+      },
+      1000,
+      false
+    ),
+    []
+  )
+
+  useEffect(() => {
+    debouncedSendImpressionEvents(toBeImpressed, push, dispatch)
+  }, [toBeImpressed, debouncedSendImpressionEvents, dispatch, push])
+}
+
+export default useProductImpression

--- a/react/utils/normalize.tsx
+++ b/react/utils/normalize.tsx
@@ -1,0 +1,36 @@
+import { pathOr } from 'ramda'
+
+import { changeImageUrlSize, toHttps } from './urlHelpers'
+
+const defaultImage = { imageUrl: '', imageLabel: '' }
+const defaultReference = { Value: '' }
+const defaultSeller = { commertialOffer: { Price: 0, ListPrice: 0 } }
+
+function findAvailableProduct(item: any) {
+  return item.sellers.find(
+    ({ commertialOffer = {} }: { commertialOffer: any }) =>
+      commertialOffer.AvailableQuantity > 0
+  )
+}
+
+export function parseToProductImpression(product: any) {
+  if (!product) return null
+  const normalizedProduct = { ...product }
+  const items = normalizedProduct.items || []
+  const sku = items.find(findAvailableProduct) || items[0]
+  if (sku) {
+    const [seller = defaultSeller] = pathOr([], ['sellers'], sku)
+    const [referenceId = defaultReference] = pathOr([], ['referenceId'], sku)
+    const [image = defaultImage] = pathOr([], ['images'], sku)
+
+    const resizedImage = changeImageUrlSize(toHttps(image.imageUrl), 500)
+    const normalizedImage = { ...image, imageUrl: resizedImage }
+    normalizedProduct.sku = {
+      ...sku,
+      seller,
+      referenceId,
+      image: normalizedImage,
+    }
+  }
+  return normalizedProduct
+}

--- a/react/utils/normalize.tsx
+++ b/react/utils/normalize.tsx
@@ -1,4 +1,4 @@
-import { pathOr } from 'ramda'
+import { pathOr, head } from 'ramda'
 
 import { changeImageUrlSize, toHttps } from './urlHelpers'
 
@@ -15,22 +15,22 @@ function findAvailableProduct(item: any) {
 
 export function parseToProductImpression(product: any) {
   if (!product) return null
-  const normalizedProduct = { ...product }
-  const items = normalizedProduct.items || []
-  const sku = items.find(findAvailableProduct) || items[0]
+  const parsedProduct = { ...product }
+  const items = parsedProduct.items || []
+  const sku = items.find(findAvailableProduct) || head(items)
   if (sku) {
     const [seller = defaultSeller] = pathOr([], ['sellers'], sku)
     const [referenceId = defaultReference] = pathOr([], ['referenceId'], sku)
     const [image = defaultImage] = pathOr([], ['images'], sku)
 
     const resizedImage = changeImageUrlSize(toHttps(image.imageUrl), 500)
-    const normalizedImage = { ...image, imageUrl: resizedImage }
-    normalizedProduct.sku = {
+    const parsedImage = { ...image, imageUrl: resizedImage }
+    parsedProduct.sku = {
       ...sku,
       seller,
       referenceId,
-      image: normalizedImage,
+      image: parsedImage,
     }
   }
-  return normalizedProduct
+  return parsedProduct
 }

--- a/react/utils/parser.tsx
+++ b/react/utils/parser.tsx
@@ -1,5 +1,7 @@
 import { pathOr, head } from 'ramda'
 
+import { Product } from '../ProductListContext'
+
 import { changeImageUrlSize, toHttps } from './urlHelpers'
 
 const defaultImage = { imageUrl: '', imageLabel: '' }
@@ -13,7 +15,7 @@ function findAvailableProduct(item: any) {
   )
 }
 
-export function parseToProductImpression(product: any) {
+export function parseToProductImpression(product: Product) {
   if (!product) return null
   const parsedProduct = { ...product }
   const items = parsedProduct.items || []

--- a/react/utils/parser.tsx
+++ b/react/utils/parser.tsx
@@ -15,8 +15,7 @@ function findAvailableProduct(item: any) {
   )
 }
 
-export function parseToProductImpression(product: Product) {
-  if (!product) return null
+export function parseToProductImpression(product: Product): Product {
   const parsedProduct = { ...product }
   const items = parsedProduct.items || []
   const sku = items.find(findAvailableProduct) || head(items)

--- a/react/utils/urlHelpers.tsx
+++ b/react/utils/urlHelpers.tsx
@@ -1,0 +1,58 @@
+export const DEFAULT_WIDTH = 'auto'
+export const DEFAULT_HEIGHT = 'auto'
+export const MAX_WIDTH = 3000
+export const MAX_HEIGHT = 4000
+
+/**
+ * Having the url below as base for the LEGACY file manager,
+ * https://storecomponents.vteximg.com.br/arquivos/ids/155472/Frame-3.jpg?v=636793763985400000
+ * the following regex will match https://storecomponents.vteximg.com.br/arquivos/ids/155472
+ *
+ * Also matches urls with defined sizes like:
+ * https://storecomponents.vteximg.com.br/arquivos/ids/155473-160-auto
+ * @type {RegExp}
+ *
+ * On the new vtex.file-manager isn't necessary replace the URL, just add the param on the querystring, like:
+ * "?width=WIDTH&height=HEIGHT&aspect=true"
+ *
+ */
+const baseUrlRegex = new RegExp(/.+ids\/(\d+)/)
+
+const httpRegex = new RegExp(/http:\/\//)
+
+export function toHttps(url: any) {
+  return url.replace(httpRegex, 'https://')
+}
+
+export function cleanImageUrl(imageUrl: any) {
+  const result = baseUrlRegex.exec(imageUrl)
+  if (!result) return
+  if (result.length > 0) return result[0]
+  return
+}
+
+function replaceLegacyFileManagerUrl(imageUrl: any, width: any, height: any) {
+  const legacyUrlPattern = '/arquivos/ids/'
+  const isLegacyUrl = imageUrl.includes(legacyUrlPattern)
+  if (!isLegacyUrl) return imageUrl
+  return `${cleanImageUrl(imageUrl)}-${width}-${height}`
+}
+
+export function changeImageUrlSize(
+  imageUrl: any,
+  width: number | string = DEFAULT_WIDTH,
+  height: number | string = DEFAULT_HEIGHT
+) {
+  if (!imageUrl) return
+  typeof width === 'number' && (width = Math.min(width, MAX_WIDTH))
+  typeof height === 'number' && (height = Math.min(height, MAX_HEIGHT))
+
+  const normalizedImageUrl = replaceLegacyFileManagerUrl(
+    imageUrl,
+    width,
+    height
+  )
+  const queryStringSeparator = normalizedImageUrl.includes('?') ? '&' : '?'
+
+  return `${normalizedImageUrl}${queryStringSeparator}width=${width}&height=${height}&aspect=true`
+}

--- a/react/utils/urlHelpers.tsx
+++ b/react/utils/urlHelpers.tsx
@@ -16,9 +16,9 @@ export const MAX_HEIGHT = 4000
  * "?width=WIDTH&height=HEIGHT&aspect=true"
  *
  */
-const baseUrlRegex = new RegExp(/.+ids\/(\d+)/)
-
-const httpRegex = new RegExp(/http:\/\//)
+const baseUrlRegex = /.+ids\/(\d+)/
+const httpRegex = /http:\/\//
+const legacyUrlPattern = '/arquivos/ids/'
 
 export function toHttps(url: any) {
   return url.replace(httpRegex, 'https://')
@@ -32,7 +32,6 @@ export function cleanImageUrl(imageUrl: any) {
 }
 
 function replaceLegacyFileManagerUrl(imageUrl: any, width: any, height: any) {
-  const legacyUrlPattern = '/arquivos/ids/'
   const isLegacyUrl = imageUrl.includes(legacyUrlPattern)
   if (!isLegacyUrl) return imageUrl
   return `${cleanImageUrl(imageUrl)}-${width}-${height}`
@@ -44,8 +43,8 @@ export function changeImageUrlSize(
   height: number | string = DEFAULT_HEIGHT
 ) {
   if (!imageUrl) return
-  typeof width === 'number' && (width = Math.min(width, MAX_WIDTH))
-  typeof height === 'number' && (height = Math.min(height, MAX_HEIGHT))
+  if (typeof width === 'number') width = Math.min(width, MAX_WIDTH)
+  if (typeof height === 'number') height = Math.min(height, MAX_HEIGHT)
 
   const normalizedImageUrl = replaceLegacyFileManagerUrl(
     imageUrl,

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -25,6 +25,11 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@types/debounce@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/debounce/-/debounce-1.2.0.tgz#9ee99259f41018c640b3929e1bb32c3dcecdb192"
+  integrity sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -68,6 +73,13 @@
   version "15.7.1"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
   integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
+
+"@types/ramda@^0.26.39":
+  version "0.26.39"
+  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.26.39.tgz#bb392cdb4d431cf6884b3ef11bef635c5d20274f"
+  integrity sha512-3bu32X02VpjJhsYPUWkdOQGoBXjb/UveZgGg4IYMm+SPAXio96BOYrRhVELfM4AoP00sxoi/f2tqrXdwtR4jjg==
+  dependencies:
+    ts-toolbelt "^4.12.0"
 
 "@types/react-intl@^2.3.18":
   version "2.3.18"
@@ -361,6 +373,11 @@ damerau-levenshtein@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz#780cf7144eb2e8dbd1c3bb83ae31100ccc31a414"
   integrity sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==
+
+debounce@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
+  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
 
 debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
@@ -1332,6 +1349,11 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+ramda@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
+
 react-apollo@^2.5.8:
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.8.tgz#c7a593b027efeefdd8399885e0ac6bec3b32623c"
@@ -1616,6 +1638,11 @@ ts-invariant@^0.4.0, ts-invariant@^0.4.2:
   dependencies:
     tslib "^1.9.3"
 
+ts-toolbelt@^4.12.0:
+  version "4.14.6"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-4.14.6.tgz#9a232f62276caeee4fa9e81e0c4bffa047de0765"
+  integrity sha512-SONcnRd93+LuYGfn/CZg5A5qhCODohZslAVZKHHu5bnwUxoXLqd2k2VIdwRUXYfKnY+UCeNbI2pTPz+Dno6Mpg==
+
 tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
@@ -1660,9 +1687,13 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-"vtex.render-runtime@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.85.0/public/@types/vtex.render-runtime":
-  version "8.85.0"
-  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.85.0/public/@types/vtex.render-runtime#497ada771894d23bcef160f481de14213be15098"
+"vtex.pixel-manager@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.pixel-manager@1.1.4/public/@types/vtex.pixel-manager":
+  version "1.1.4"
+  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.pixel-manager@1.1.4/public/@types/vtex.pixel-manager#96907e17f4e5c584162a47dc425cb5afb2267d00"
+
+"vtex.render-runtime@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.87.3/public/@types/vtex.render-runtime":
+  version "8.87.3"
+  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.87.3/public/@types/vtex.render-runtime#669ebbfb693e6d9f259d4312b32e5c39158fee11"
 
 which@^1.2.9:
   version "1.3.1"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1691,9 +1691,9 @@ validate-npm-package-license@^3.0.1:
   version "1.1.4"
   resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.pixel-manager@1.1.4/public/@types/vtex.pixel-manager#96907e17f4e5c584162a47dc425cb5afb2267d00"
 
-"vtex.render-runtime@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.87.3/public/@types/vtex.render-runtime":
-  version "8.87.3"
-  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.87.3/public/@types/vtex.render-runtime#669ebbfb693e6d9f259d4312b32e5c39158fee11"
+"vtex.render-runtime@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.88.0/public/@types/vtex.render-runtime":
+  version "8.88.0"
+  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.88.0/public/@types/vtex.render-runtime#0257088b54c76eec74477e5dd9014d5b38779ac7"
 
 which@^1.2.9:
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,16 +96,6 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@vtex/intl-equalizer@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@vtex/intl-equalizer/-/intl-equalizer-2.3.0.tgz#f37fd0ad1a85d6eb34867d9024bbd487c7ff4982"
-  integrity sha512-+I9wo0+VqASYrtBZ9SBaDUxaBNB2HCeBQcVyxdSRdz4YXyvr4ig6FqwZgIq08vugTrpBppXgXdUwdXQLfchp6w==
-  dependencies:
-    cli-table2 "^0.2.0"
-    commander "^2.19.0"
-    diff "^4.0.1"
-    util "^0.11.0"
-
 acorn-jsx@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
@@ -132,11 +122,6 @@ ansi-escapes@^4.2.1:
   integrity sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==
   dependencies:
     type-fest "^0.8.1"
-
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
 ansi-regex@^4.1.0:
   version "4.1.0"
@@ -267,25 +252,10 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-table2@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/cli-table2/-/cli-table2-0.2.0.tgz#2d1ef7f218a0e786e214540562d4bd177fe32d97"
-  integrity sha1-LR738hig54biFFQFYtS9F3/jLZc=
-  dependencies:
-    lodash "^3.10.1"
-    string-width "^1.0.1"
-  optionalDependencies:
-    colors "^1.1.2"
-
 cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
-
-code-point-at@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
-  integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -299,20 +269,10 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-colors@^1.1.2:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
-  integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
-
 commander@^2.11.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
-commander@^2.19.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
-  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -380,11 +340,6 @@ define-properties@^1.1.2, define-properties@^1.1.3:
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
-
-diff@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
-  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
 
 doctrine@1.5.0:
   version "1.5.0"
@@ -922,11 +877,6 @@ inherits@2:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-inherits@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
-
 inquirer@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.1.tgz#13f7980eedc73c689feff3994b109c4e799c6ebb"
@@ -977,13 +927,6 @@ is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
-
-is-fullwidth-code-point@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
-  integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
-  dependencies:
-    number-is-nan "^1.0.0"
 
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
@@ -1123,11 +1066,6 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@^3.10.1:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-  integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
-
 lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
@@ -1205,11 +1143,6 @@ npm-run-path@^2.0.0:
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
-
-number-is-nan@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
-  integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
 object-assign@^4.1.1:
   version "4.1.1"
@@ -1668,15 +1601,6 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-string-width@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
-  integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    strip-ansi "^3.0.0"
-
 string-width@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
@@ -1710,13 +1634,6 @@ string.prototype.trimright@^2.1.0:
   dependencies:
     define-properties "^1.1.3"
     function-bind "^1.1.1"
-
-strip-ansi@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
-  dependencies:
-    ansi-regex "^2.0.0"
 
 strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
@@ -1821,13 +1738,6 @@ uri-js@^4.2.2:
   integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   dependencies:
     punycode "^2.1.0"
-
-util@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
-  integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
-  dependencies:
-    inherits "2.0.3"
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
#### What does this PR do? \*

Implement the `useProductImpression` hook which is responsible for checking the `toBeImpressed` prop of the `ProductListContext` and sending the `productImpression` event when the time is right. To better reflect this new feature, the actions and state props were renamed to better represent their roles.

**IS THIS A BREAKING CHANGE!?** 
Yes, but this app is new and I believe nobody is using it yet >:D

#### How to test it? \*

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/)
then on console type `pixelManagerEvents` to check the events that are being sent when you see the shelf.

#### To be done before this PR is ready for merge:
- type things
- maybe rename more stuff
- changelog
- readme

