### PR TITLE
Fixing concurrency on impressions of a list of products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Concurrency when calculating impression position of a list of products
 
 ## [0.3.1] - 2020-12-17
 ### Fixed


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes the concurrencies happening when a list of products was displayed and their Product Impressions events were queued. Because of little, frequent differences between renders and products, some products rendered faster and thus entered the queue faster, receiving the wrong position from the handler.

This PR adds a new field called position, received from the event senders. This identifies the position of the product inside the list, and is used to organize the current queue. The events are now consistent between renders, and follow the order they are presented on screen.

#### How to test it?

[Workspace](https://icarogtmprod--storecomponents.myvtex.com/)

#### Related to / Depends on

Related to [https://github.com/vtex-apps/google-tag-manager/pull/51](https://github.com/vtex-apps/google-tag-manager/pull/51)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/bcbPzkSCytDH2/giphy.gif)
